### PR TITLE
    Fix a crash when parsing HTML with XPath.

### DIFF
--- a/Pod/Classes/XPathQuery.m
+++ b/Pod/Classes/XPathQuery.m
@@ -30,6 +30,9 @@ NSDictionary *DictionaryForNode(xmlNodePtr currentNode, NSMutableDictionary *par
     if (nodeContent != NULL) {
         NSString *currentNodeContent = [NSString stringWithCString:(const char *)nodeContent
                                                           encoding:NSUTF8StringEncoding];
+        if (currentNodeContent == nil) {
+            currentNodeContent = @"";
+        }
         if ([resultForNode[@"nodeName"] isEqual:@"text"] && parentResult) {
             if (parentContent) {
                 NSCharacterSet *charactersToTrim = [NSCharacterSet whitespaceAndNewlineCharacterSet];


### PR DESCRIPTION
    some html data delcared in utf8,but it contains some unicode char.
    hpple's XPathQuery.m:31,40,44 will lead to crash(set nil object to dictionary).